### PR TITLE
Use pathspec + Enforce UTF-8 encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,8 @@ dist/
 wheels/
 *.egg-info
 
+# pytest
+.coverage
+
 # venv
 .venv

--- a/LICENSES_THIRD_PARTY
+++ b/LICENSES_THIRD_PARTY
@@ -12,6 +12,8 @@ Third party Python packages listed by license type
 --------------------------------------------------
 
 MIT License (https://opensource.org/license/mit)
-  * gitignore-parser - https://github.com/mherrmann/gitignore_parser/blob/master/LICENSE
   * rich - https://github.com/Textualize/rich/blob/master/LICENSE
   * typer - https://github.com/fastapi/typer/blob/master/LICENSE
+
+Mozilla Public License 2.0 (https://opensource.org/license/mpl-2-0)
+  * pathspec - https://github.com/cpburnz/python-pathspec/blob/master/LICENSE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     { name = "Nan Xiao", email = "nan.xiao1@msd.com" }
 ]
 dependencies = [
-    "gitignore-parser>=0.1.11",
+    "pathspec>=0.12.1",
     "rich>=13.9.4",
     "typer>=0.12.5",
 ]

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -69,8 +69,6 @@ fqdn==1.5.1
     # via jsonschema
 ghp-import==2.1.0
     # via mkdocs
-gitignore-parser==0.1.11
-    # via pkglite
 griffe==1.5.4
     # via mkdocstrings-python
 h11==0.14.0
@@ -230,6 +228,7 @@ parso==0.8.4
     # via jedi
 pathspec==0.12.1
     # via mkdocs
+    # via pkglite
 pexpect==4.9.0
     # via ipython
 platformdirs==4.3.6

--- a/requirements.lock
+++ b/requirements.lock
@@ -12,12 +12,12 @@
 -e file:.
 click==8.1.8
     # via typer
-gitignore-parser==0.1.11
-    # via pkglite
 markdown-it-py==3.0.0
     # via rich
 mdurl==0.1.2
     # via markdown-it-py
+pathspec==0.12.1
+    # via pkglite
 pygments==2.19.1
     # via rich
 rich==13.9.4

--- a/src/pkglite/pack.py
+++ b/src/pkglite/pack.py
@@ -31,7 +31,7 @@ def load_ignore_matcher(directory: str) -> Callable[[str], bool]:
     if not os.path.exists(ignore_path):
         return lambda path: False
 
-    with open(ignore_path, "r") as f:
+    with open(ignore_path, "r", encoding="utf-8") as f:
         patterns = f.readlines()
 
     spec = PathSpec.from_lines("gitwildmatch", patterns)

--- a/src/pkglite/pack.py
+++ b/src/pkglite/pack.py
@@ -50,10 +50,7 @@ def load_ignore_matcher(directory: str) -> Callable[[str], bool]:
         if os.path.isabs(path):
             path = os.path.relpath(path, abs_dir)
 
-        # Convert Windows path separators to forward slashes
-        norm_path = path.replace(os.sep, "/")
-
-        return spec.match_file(norm_path)
+        return spec.match_file(path)
 
     return matcher
 

--- a/src/pkglite/pack.py
+++ b/src/pkglite/pack.py
@@ -101,7 +101,7 @@ def read_text_content(file_path: str) -> str:
     Returns:
         str: Formatted text content.
     """
-    with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
+    with open(file_path, "r", encoding="utf-8") as f:
         return "".join("  " + line for line in f)
 
 
@@ -205,7 +205,7 @@ def pack(
 
     os.makedirs(os.path.dirname(abs_output), exist_ok=True)
 
-    with open(abs_output, "w") as out:
+    with open(abs_output, "w", encoding="utf-8") as out:
         out.write(create_header())
 
         for directory in abs_dirs:

--- a/src/pkglite/unpack.py
+++ b/src/pkglite/unpack.py
@@ -99,7 +99,7 @@ def parse_packed_file(input_file: str) -> List[FileData]:
     content_lines: List[str] = []
     in_content = False
 
-    with open(input_file, "r") as f:
+    with open(input_file, "r", encoding="utf-8") as f:
         for line in f:
             line = line.rstrip()
 


### PR DESCRIPTION
Fixes #4 
Fixes #6 

This PR replaced gitignore-parser with pathspec for handling ignore pattern matching. This makes packing work properly under Windows (thanks to the unit test for signifying this issue).

Also enforces reading and writing all text files using UTF-8 encoding on all platforms. This is simply the right thing to do, for saving everyone from avoidable headaches in the long run.