### PR TITLE
Use shorthand syntax for unions

### DIFF
--- a/src/pkglite/classify.py
+++ b/src/pkglite/classify.py
@@ -1,8 +1,8 @@
 import os
-from typing import FrozenSet, Optional
+from typing import FrozenSet
 
 
-def is_text_file(path: str, n: Optional[int] = None) -> bool:
+def is_text_file(path: str, n: int | None = None) -> bool:
     """
     Classify any file as text or binary.
 

--- a/src/pkglite/pack.py
+++ b/src/pkglite/pack.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import List, Callable, Tuple, Optional
+from typing import Callable
 
 from pathspec import PathSpec
 
@@ -142,7 +142,7 @@ def process_single_file(
     directory: str,
     package_name: str,
     ignore_matcher: Callable[[str], bool],
-) -> Optional[str]:
+) -> str | None:
     """
     Process a single file and return its formatted content.
 
@@ -153,7 +153,7 @@ def process_single_file(
         ignore_matcher (function): Function to check if file should be ignored.
 
     Returns:
-        Optional[str]: Formatted file content if not ignored, None otherwise.
+        str | None: Formatted file content if not ignored, None otherwise.
     """
     if ignore_matcher(file_path):
         return None
@@ -182,7 +182,7 @@ def create_header() -> str:
 
 
 def pack(
-    input_dirs: str | List[str] | Path,
+    input_dirs: str | Path | list[str | Path],
     output_file: str | Path = Path("pkglite.txt"),
     quiet: bool = False,
 ) -> None:
@@ -190,7 +190,7 @@ def pack(
     Pack files from one or multiple directories into a text file.
 
     Args:
-        input_dirs (str or list or Path): Path or list of paths to the
+        input_dirs (str or Path or list): Path or list of paths to the
             directories to pack.
         output_file (str or Path): Path to the output file.
             Default is 'pkglite.txt'.

--- a/src/pkglite/unpack.py
+++ b/src/pkglite/unpack.py
@@ -1,6 +1,6 @@
 import os
 import binascii
-from typing import List, Dict, Set, Optional
+from typing import List, Dict, Set
 from pathlib import Path
 from dataclasses import dataclass
 
@@ -21,7 +21,7 @@ class FileData:
     content: str
 
 
-def extract_metadata_field(line: str, tag: str) -> Optional[str]:
+def extract_metadata_field(line: str, tag: str) -> str | None:
     """
     Extract a metadata field value from a line with a given tag.
 
@@ -30,7 +30,7 @@ def extract_metadata_field(line: str, tag: str) -> Optional[str]:
         tag (str): The tag to look for.
 
     Returns:
-        Optional[str]: The extracted value if found, None otherwise.
+        str | None: The extracted value if found, None otherwise.
     """
     return line.split(f"{tag}: ")[1] if line.startswith(f"{tag}: ") else None
 
@@ -81,7 +81,17 @@ def parse_packed_file(input_file: str) -> List[FileData]:
 
     def process_file_entry(
         current: Dict[str, str], lines: List[str]
-    ) -> Optional[FileData]:
+    ) -> FileData | None:
+        """
+        Process a file entry and create a FileData object.
+
+        Args:
+            current: Dictionary containing current file metadata.
+            lines: List of content lines.
+
+        Returns:
+            FileData | None: FileData object if valid entry, None otherwise.
+        """
         if not (current and "package" in current and "path" in current):
             return None
         content = create_file_entry(

--- a/src/pkglite/use.py
+++ b/src/pkglite/use.py
@@ -2,14 +2,14 @@ import os
 import shutil
 import importlib.resources as pkg_resources
 from pathlib import Path
-from typing import List, Union, Tuple
+from typing import List, Tuple
 
 import pkglite.templates
 from .cli import print_success, print_warning, format_path
 
 
 def process_directory(
-    template: Path, directory: Union[str, Path], force: bool, quiet: bool
+    template: Path, directory: str | Path, force: bool, quiet: bool
 ) -> Tuple[str, bool]:
     """
     Process a single directory and create/overwrite `.pkgliteignore` file.
@@ -50,9 +50,7 @@ def process_directory(
 
 
 def use_pkglite(
-    input_dirs: Union[str, Path, List[Union[str, Path]]],
-    force: bool = False,
-    quiet: bool = False,
+    input_dirs: str | Path | list[str | Path], force: bool = False, quiet: bool = False
 ) -> List[str]:
     """
     Copy the `.pkgliteignore` template into one or more directories.


### PR DESCRIPTION
Fixes #8 

This PR updates the type annotations to use shorthand syntax for unions defined by PEP 604 and recommended by the Typing Best Practices article.