### PR TITLE
Use more generic types

### DIFF
--- a/src/pkglite/classify.py
+++ b/src/pkglite/classify.py
@@ -10,11 +10,11 @@ def is_text_file(path: str, n: int | None = None) -> bool:
     in zlib (`doc/txtvsbin.txt`).
 
     Args:
-        path (str): File path.
-        n (int, optional): Maximal number of bytes to read. Defaults to file size.
+        path: File path.
+        n: Maximal number of bytes to read. Defaults to file size.
 
     Returns:
-        bool: True if the file is text, False if binary.
+        True if the file is text, False if binary.
     """
     ALLOW: FrozenSet[int] = frozenset([9, 10, 13] + list(range(32, 256)))
     BLOCK: FrozenSet[int] = frozenset(list(range(0, 7)) + list(range(14, 32)))
@@ -33,12 +33,12 @@ def is_text_file(path: str, n: int | None = None) -> bool:
 
 def classify_file(path: str) -> str:
     """
-    Classify file as 'text' or 'binary'.
+    Classify file as text or binary.
 
     Args:
-        path (str): Path to the file to classify.
+        path: Path to the file to classify.
 
     Returns:
-        str: 'text' if the file is detected as text, 'binary' otherwise.
+        `'text'` if the file is detected as text, `'binary'` otherwise.
     """
     return "text" if is_text_file(path) else "binary"

--- a/src/pkglite/main.py
+++ b/src/pkglite/main.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Annotated
+from typing import Annotated
 
 import typer
 
@@ -19,7 +19,7 @@ def callback():
 
 @app.command()
 def pack(
-    input_dirs: List[Path],
+    input_dirs: list[Path],
     output_file: Annotated[Path, typer.Option("--output-file", "-o")] = Path(
         "pkglite.txt"
     ),
@@ -55,7 +55,7 @@ def unpack(
 
 @app.command()
 def use(
-    input_dirs: List[Path],
+    input_dirs: list[Path],
     force: Annotated[bool, typer.Option("--force", "-f")] = False,
     quiet: Annotated[bool, typer.Option("--quiet", "-q")] = False,
 ):

--- a/src/pkglite/unpack.py
+++ b/src/pkglite/unpack.py
@@ -1,6 +1,6 @@
 import os
 import binascii
-from typing import List, Dict, Set
+from collections.abc import Sequence
 from pathlib import Path
 from dataclasses import dataclass
 
@@ -26,28 +26,28 @@ def extract_metadata_field(line: str, tag: str) -> str | None:
     Extract a metadata field value from a line with a given tag.
 
     Args:
-        line (str): The line to extract from.
-        tag (str): The tag to look for.
+        line: The line to extract from.
+        tag: The tag to look for.
 
     Returns:
-        str | None: The extracted value if found, None otherwise.
+        The extracted value if found, None otherwise.
     """
     return line.split(f"{tag}: ")[1] if line.startswith(f"{tag}: ") else None
 
 
 def create_file_entry(
-    package_name: str, content_lines: List[str], file_format: str
-) -> Dict[str, str]:
+    package_name: str, content_lines: list[str], file_format: str
+) -> dict[str, str]:
     """
     Create a file entry dictionary with the given content.
 
     Args:
-        package_name (str): Name of the package.
-        content_lines (list): List of content lines.
-        file_format (str): Format of the file ('text' or 'binary').
+        package_name: Name of the package.
+        content_lines: List of content lines.
+        file_format: Format of the file ('text' or 'binary').
 
     Returns:
-        Dict[str, str]: Dictionary containing the file entry data.
+        Dictionary containing the file entry data.
     """
     content = (
         "\n".join(content_lines) if file_format == "text" else "".join(content_lines)
@@ -60,27 +60,27 @@ def process_content_line(line: str) -> str:
     Process a content line by removing the leading spaces if present.
 
     Args:
-        line (str): The line to process.
+        line: The line to process.
 
     Returns:
-        str: The processed line with leading spaces removed if present.
+        The processed line with leading spaces removed if present.
     """
     return line[2:] if line.startswith("  ") else ""
 
 
-def parse_packed_file(input_file: str) -> List[FileData]:
+def parse_packed_file(input_file: str) -> Sequence[FileData]:
     """
     Parse the packed text file and extract file data.
 
     Args:
-        input_file (str): Path to the packed file.
+        input_file: Path to the packed file.
 
     Returns:
-        List[FileData]: A list of FileData objects containing file information.
+        A sequence of FileData objects containing file information.
     """
 
     def process_file_entry(
-        current: Dict[str, str], lines: List[str]
+        current: dict[str, str], lines: list[str]
     ) -> FileData | None:
         """
         Process a file entry and create a FileData object.
@@ -90,7 +90,7 @@ def parse_packed_file(input_file: str) -> List[FileData]:
             lines: List of content lines.
 
         Returns:
-            FileData | None: FileData object if valid entry, None otherwise.
+            FileData object if valid entry, None otherwise.
         """
         if not (current and "package" in current and "path" in current):
             return None
@@ -104,9 +104,9 @@ def parse_packed_file(input_file: str) -> List[FileData]:
             content=content["content"],
         )
 
-    files: List[FileData] = []
-    current_file: Dict[str, str] = {}
-    content_lines: List[str] = []
+    files: list[FileData] = []
+    current_file: dict[str, str] = {}
+    content_lines: list[str] = []
     in_content = False
 
     with open(input_file, "r", encoding="utf-8") as f:
@@ -151,8 +151,8 @@ def write_text_file(file_path: Path, content: str) -> None:
     Write content to a text file.
 
     Args:
-        file_path (Path): Path to the file to write.
-        content (str): Text content to write.
+        file_path: Path to the file to write.
+        content: Text content to write.
     """
     file_path.parent.mkdir(parents=True, exist_ok=True)
     file_path.write_text(content, encoding="utf-8")
@@ -163,8 +163,8 @@ def write_binary_file(file_path: Path, content: str) -> None:
     Write hex content to a binary file.
 
     Args:
-        file_path (Path): Path to the file to write.
-        content (str): Hexadecimal string content to write.
+        file_path: Path to the file to write.
+        content: Hexadecimal string content to write.
 
     Raises:
         ValueError: If the content is not valid hexadecimal.
@@ -182,8 +182,8 @@ def write_file(file_data: FileData, output_directory: Path) -> None:
     Write a file to the specified output directory.
 
     Args:
-        file_data (FileData): FileData object containing file information
-        output_directory (Path): Root directory for unpacked files.
+        file_data: FileData object containing file information
+        output_directory: Root directory for unpacked files.
     """
     file_path = output_directory / file_data.package / file_data.path
 
@@ -200,19 +200,18 @@ def unpack(
     Unpack files from a text file into the specified directory.
 
     Args:
-        input_file (str or Path): Path to the packed file.
-        output_dir (str or Path): Path to the directory to unpack files into.
-            Default is current directory.
-        quiet (bool): If True, suppress output messages. Default False.
+        input_file: Path to the packed file.
+        output_dir: Path to the directory to unpack files into.
+        quiet: If True, suppress output messages.
     """
     input_path = Path(os.path.expanduser(str(input_file)))
     output_path = Path(os.path.expanduser(str(output_dir)))
 
     files = parse_packed_file(str(input_path))
-    packages: Set[str] = {file_data.package for file_data in files}
+    packages: set[str] = {file_data.package for file_data in files}
 
     # Group files by package
-    files_by_package: Dict[str, List[FileData]] = {}
+    files_by_package: dict[str, list[FileData]] = {}
     for file_data in files:
         pkg = file_data.package
         if pkg not in files_by_package:

--- a/src/pkglite/use.py
+++ b/src/pkglite/use.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import importlib.resources as pkg_resources
 from pathlib import Path
-from typing import List, Tuple
+from typing import Tuple
 
 import pkglite.templates
 from .cli import print_success, print_warning, format_path
@@ -15,18 +15,13 @@ def process_directory(
     Process a single directory and create/overwrite `.pkgliteignore` file.
 
     Args:
-        template (Path): Path to the template `.pkgliteignore` file to copy from.
-        directory (str or Path): Path to the directory to process.
-        force (bool): If True, overwrite existing `.pkgliteignore` file.
-        quiet (bool): If True, suppress output messages.
+        template: Path to the template `.pkgliteignore` file to copy from.
+        directory: Path to the directory to process.
+        force: If True, overwrite existing `.pkgliteignore` file.
+        quiet: If True, suppress output messages.
 
     Returns:
-        Tuple[str, bool]: A tuple containing:
-            - str: Path to the `.pkgliteignore` file.
-            - bool: Whether the file was created/overwritten.
-
-    Raises:
-        OSError: If there are permission errors creating directory or copying file.
+        A tuple containing the path to the `.pkgliteignore` file and whether it was created/overwritten.
     """
     dir_path = Path(os.path.abspath(os.path.expanduser(str(directory))))
     ignore_path = str(dir_path / ".pkgliteignore")
@@ -51,18 +46,17 @@ def process_directory(
 
 def use_pkglite(
     input_dirs: str | Path | list[str | Path], force: bool = False, quiet: bool = False
-) -> List[str]:
+) -> list[str]:
     """
     Copy the `.pkgliteignore` template into one or more directories.
 
     Args:
-        input_dirs (str or Path or list): Path or list of paths to directories
-            where `.pkgliteignore` should be placed.
-        force (bool): If True, overwrite existing `.pkgliteignore` files. Default is False.
-        quiet (bool): If True, suppress output messages. Default is False.
+        input_dirs: Path or sequence of paths to directories for `.pkgliteignore`.
+        force: If True, overwrite existing `.pkgliteignore` files.
+        quiet: If True, suppress output messages.
 
     Returns:
-        list: Paths to the newly created or existing `.pkgliteignore` files.
+        Paths to the newly created or existing `.pkgliteignore` files.
     """
     dirs = [input_dirs] if isinstance(input_dirs, (str, Path)) else input_dirs
 


### PR DESCRIPTION
Closes #9 

This PR updates the type annotations to use built-in generics instead of the aliases from typing + use more generic types from collections.abc, following [Typing Best Practices](https://typing.readthedocs.io/en/latest/reference/best_practices.html#built-in-generics).