### PR TITLE
Run isort to sort imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ packages = ["src/pkglite"]
 [tool.rye]
 managed = true
 dev-dependencies = [
-    "ruff>=0.8.6",
     "pytest>=8.3.4",
     "pytest-cov>=6.0.0",
     "mkdocs>=1.6.1",
@@ -65,6 +64,8 @@ dev-dependencies = [
     "mkdocstrings-python>=1.13.0",
     "nbconvert>=7.16.5",
     "jupyter>=1.1.1",
+    "ruff>=0.9.1",
+    "isort>=5.13.2",
 ]
 
 [tool.pytest.ini_options]

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -96,6 +96,7 @@ ipywidgets==8.1.5
     # via jupyter
 isoduration==20.11.0
     # via jsonschema
+isort==5.13.2
 jedi==0.19.2
     # via ipython
 jinja2==3.1.5

--- a/src/pkglite/__init__.py
+++ b/src/pkglite/__init__.py
@@ -1,4 +1,4 @@
-from .classify import is_text_file, classify_file
+from .classify import classify_file, is_text_file
 from .pack import pack
 from .unpack import unpack
 from .use import use_pkglite

--- a/src/pkglite/pack.py
+++ b/src/pkglite/pack.py
@@ -1,17 +1,17 @@
 import os
-from pathlib import Path
 from collections.abc import Callable
+from pathlib import Path
 from typing import Protocol
 
 from pathspec import PathSpec
 
 from .classify import classify_file
 from .cli import (
+    format_count,
+    format_path,
     print_action,
     print_sub_action,
     print_success,
-    format_path,
-    format_count,
 )
 
 

--- a/src/pkglite/unpack.py
+++ b/src/pkglite/unpack.py
@@ -1,15 +1,15 @@
-import os
 import binascii
+import os
 from collections.abc import Sequence
-from pathlib import Path
 from dataclasses import dataclass
+from pathlib import Path
 
 from .cli import (
+    format_count,
+    format_path,
     print_action,
     print_sub_action,
     print_success,
-    format_path,
-    format_count,
 )
 
 

--- a/src/pkglite/use.py
+++ b/src/pkglite/use.py
@@ -1,11 +1,12 @@
+import importlib.resources as pkg_resources
 import os
 import shutil
-import importlib.resources as pkg_resources
 from pathlib import Path
 from typing import Tuple
 
 import pkglite.templates
-from .cli import print_success, print_warning, format_path
+
+from .cli import format_path, print_success, print_warning
 
 
 def process_directory(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,9 +3,8 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from typer.testing import CliRunner
-
 from pkglite.main import app
+from typer.testing import CliRunner
 
 runner = CliRunner()
 

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -1,4 +1,4 @@
-from pkglite.pack import pack, load_ignore_matcher
+from pkglite.pack import load_ignore_matcher, pack
 
 
 def test_pack_single_directory(tmp_path):

--- a/tests/test_unpack.py
+++ b/tests/test_unpack.py
@@ -1,4 +1,4 @@
-from pkglite.unpack import unpack, parse_packed_file
+from pkglite.unpack import parse_packed_file, unpack
 
 
 def test_unpack_text_files(tmp_path):


### PR DESCRIPTION
This PR runs `isort .` to sort import statements for all `.py` files.