### PR TITLE
Rewrite packed file parser with finite state machines

### DIFF
--- a/src/pkglite/unpack.py
+++ b/src/pkglite/unpack.py
@@ -2,6 +2,7 @@ import binascii
 import os
 from collections.abc import Sequence
 from dataclasses import dataclass
+from enum import Enum, auto
 from pathlib import Path
 
 from .cli import (
@@ -68,9 +69,17 @@ def process_content_line(line: str) -> str:
     return line[2:] if line.startswith("  ") else ""
 
 
+class ParserState(Enum):
+    """States for the packed file parser state machine."""
+
+    EXPECTING_PACKAGE = auto()  # Initial state, expecting Package: line
+    EXPECTING_METADATA = auto()  # Expecting File: or Format: or Content:
+    READING_CONTENT = auto()  # Reading content lines
+
+
 def parse_packed_file(input_file: str) -> Sequence[FileData]:
     """
-    Parse the packed text file and extract file data.
+    Parse the packed text file and extract file data using a finite state machine.
 
     Args:
         input_file: Path to the packed file.
@@ -104,43 +113,78 @@ def parse_packed_file(input_file: str) -> Sequence[FileData]:
             content=content["content"],
         )
 
+    def handle_package_state(line: str) -> tuple[ParserState, dict[str, str] | None]:
+        """Handle EXPECTING_PACKAGE state."""
+        if package_name := extract_metadata_field(line, "Package"):
+            return ParserState.EXPECTING_METADATA, {"package": package_name}
+        return ParserState.EXPECTING_PACKAGE, None
+
+    def handle_metadata_state(
+        line: str, current: dict[str, str]
+    ) -> tuple[ParserState, bool]:
+        """Handle EXPECTING_METADATA state. Returns (new_state, metadata_updated)."""
+        if path := extract_metadata_field(line, "File"):
+            current["path"] = path
+            return ParserState.EXPECTING_METADATA, True
+
+        if file_format := extract_metadata_field(line, "Format"):
+            current["format"] = file_format
+            return ParserState.EXPECTING_METADATA, True
+
+        if line == "Content:":
+            return ParserState.READING_CONTENT, True
+
+        return ParserState.EXPECTING_METADATA, False
+
+    def finalize_current_entry(
+        current: dict[str, str], content_lines: list[str]
+    ) -> FileData | None:
+        """Create FileData from current entry if valid."""
+        if file_data := process_file_entry(current, content_lines):
+            return file_data
+        return None
+
     files: list[FileData] = []
     current_file: dict[str, str] = {}
     content_lines: list[str] = []
-    in_content = False
+    state = ParserState.EXPECTING_PACKAGE
 
     with open(input_file, "r", encoding="utf-8") as f:
         for line in f:
             line = line.rstrip()
 
-            package_name = extract_metadata_field(line, "Package")
-            if package_name:
+            if state == ParserState.EXPECTING_PACKAGE:
+                # Handle transition from current package to new package
                 if current_file:
-                    if file_data := process_file_entry(current_file, content_lines):
+                    if file_data := finalize_current_entry(current_file, content_lines):
                         files.append(file_data)
-                current_file = {"package": package_name}
-                content_lines = []
-                in_content = False
-                continue
 
-            if not in_content:
-                path = extract_metadata_field(line, "File")
-                if path:
-                    current_file["path"] = path
-                    continue
+                new_state, new_file = handle_package_state(line)
+                if new_file:
+                    current_file = new_file
+                    content_lines = []
+                    state = new_state
 
-                file_format = extract_metadata_field(line, "Format")
-                if file_format:
-                    current_file["format"] = file_format
-                    continue
+            elif state == ParserState.EXPECTING_METADATA:
+                new_state, updated = handle_metadata_state(line, current_file)
+                if updated:
+                    state = new_state
 
-                if line == "Content:":
-                    in_content = True
-                    continue
-            else:
-                content_lines.append(process_content_line(line))
+            elif state == ParserState.READING_CONTENT:
+                if package_name := extract_metadata_field(line, "Package"):
+                    # New package found while reading content
+                    if file_data := finalize_current_entry(current_file, content_lines):
+                        files.append(file_data)
+                    current_file = {"package": package_name}
+                    content_lines = []
+                    state = ParserState.EXPECTING_METADATA
+                else:
+                    content_lines.append(process_content_line(line))
 
-        if file_data := process_file_entry(current_file, content_lines):
+        # Handle the last file entry
+        if current_file and (
+            file_data := finalize_current_entry(current_file, content_lines)
+        ):
             files.append(file_data)
 
     return files


### PR DESCRIPTION
Closes #14 

This PR rewrites the packed file parser using finite state machines. The current implementation uses a stateful approach. The new implementation makes the parser easier to read and maintain.

Using the following shell script, I did some real-world tests to compare the `pkglite unpack` output directories (one or multiple) from this implementation and the existing implementation.

<details><summary>compare.sh</summary>

```bash
#!/bin/bash

function compute_md5 {
    md5 "$1" | awk '{print $4}'
}

function compare_directories {
    local dir1="$1"
    local dir2="$2"
    local mismatch_count=0

    IFS=$'\n' dir1_files=($(find "$dir1" -type f -o -type d | sort))
    IFS=$'\n' dir2_files=($(find "$dir2" -type f -o -type d | sort))

    # Normalize paths
    dir1_base_len=${#dir1}
    dir2_base_len=${#dir2}
    for i in "${!dir1_files[@]}"; do
        dir1_files[$i]="${dir1_files[$i]:$dir1_base_len}"
    done
    for i in "${!dir2_files[@]}"; do
        dir2_files[$i]="${dir2_files[$i]:$dir2_base_len}"
    done

    # Check if directory structures match
    if [ "${#dir1_files[@]}" -ne "${#dir2_files[@]}" ]; then
        echo "Directory structures differ."
        echo "Extra files or directories:" >&2
        diff <(printf "%s\n" "${dir1_files[@]}") <(printf "%s\n" "${dir2_files[@]}") | head -10 >&2
        exit 1
    fi

    for i in "${!dir1_files[@]}"; do
        if [ "${dir1_files[i]}" != "${dir2_files[i]}" ]; then
            echo "Mismatch in directory structure: ${dir1_files[i]} vs ${dir2_files[i]}"
            mismatch_count=$((mismatch_count + 1))
            if [ $mismatch_count -ge 10 ]; then break; fi
        fi
    done

    # Check file contents match
    for i in "${!dir1_files[@]}"; do
        local path1="$dir1/${dir1_files[i]}"
        local path2="$dir2/${dir2_files[i]}"

        # Skip directories
        if [ -d "$path1" ]; then
            continue
        fi

        if ! cmp -s "$path1" "$path2"; then
            echo "File content mismatch: $path1 vs $path2"
            mismatch_count=$((mismatch_count + 1))
            if [ $mismatch_count -ge 10 ]; then break; fi
        fi
    done

    if [ $mismatch_count -eq 0 ]; then
        echo "Directories are identical."
    else
        echo "Directories differ. See details above."
    fi
}

# Check arguments
if [ "$#" -ne 2 ]; then
    echo "Usage: $0 <directory1> <directory2>"
    exit 1
fi

# Compare directories
compare_directories "$1" "$2"
```

</details>

They are identical.