### PR TITLE
Use absolute URL logo in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pkglite for Python <img src="docs/assets/logo.png" align="right" width="120" />
+# pkglite for Python <img src="https://github.com/pharmaverse/py-pkglite/raw/main/docs/assets/logo.png" align="right" width="120" />
 
 [![PyPI version](https://img.shields.io/pypi/v/pkglite)](https://pypi.org/project/pkglite/)
 ![Python versions](https://img.shields.io/pypi/pyversions/pkglite)

--- a/docs/scripts/sync.sh
+++ b/docs/scripts/sync.sh
@@ -35,7 +35,7 @@ for article in get-started; do
 done
 
 # Sync README.md with modified image path for docs/index.md
-awk '{gsub("docs/assets/logo.png", "assets/logo.png"); print}' README.md >docs/index.md
+awk '{gsub("https://github.com/pharmaverse/py-pkglite/raw/main/docs/assets/logo.png", "assets/logo.png"); print}' README.md >docs/index.md
 
 # Sync CHANGELOG.md with docs/changelog.md
 cp CHANGELOG.md docs/changelog.md

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -35,7 +35,7 @@ beautifulsoup4==4.12.3
     # via nbconvert
 bleach==6.2.0
     # via nbconvert
-certifi==2024.12.14
+certifi==2025.1.31
     # via httpcore
     # via httpx
     # via requests
@@ -69,7 +69,7 @@ fqdn==1.5.1
     # via jsonschema
 ghp-import==2.1.0
     # via mkdocs
-griffe==1.5.5
+griffe==1.5.6
     # via mkdocstrings-python
 h11==0.14.0
     # via httpcore
@@ -146,7 +146,7 @@ jupyter-server==2.15.0
     # via notebook-shim
 jupyter-server-terminals==0.5.3
     # via jupyter-server
-jupyterlab==4.3.4
+jupyterlab==4.3.5
     # via jupyter
     # via notebook
 jupyterlab-pygments==0.3.0
@@ -189,7 +189,7 @@ mkdocs-autorefs==1.2.0
     # via mkdocstrings-python
 mkdocs-get-deps==0.2.0
     # via mkdocs
-mkdocs-material==9.5.50
+mkdocs-material==9.6.0
 mkdocs-material-extensions==1.3.1
     # via mkdocs-material
 mkdocstrings==0.27.0
@@ -278,7 +278,7 @@ pyyaml==6.0.2
     # via pyyaml-env-tag
 pyyaml-env-tag==0.1
     # via mkdocs
-pyzmq==26.2.0
+pyzmq==26.2.1
     # via ipykernel
     # via jupyter-client
     # via jupyter-console
@@ -304,7 +304,7 @@ rich==13.9.4
 rpds-py==0.22.3
     # via jsonschema
     # via referencing
-ruff==0.9.3
+ruff==0.9.4
 send2trash==1.8.3
     # via jupyter-server
 setuptools==75.8.0


### PR DESCRIPTION
For logo in `README.md`, this PR uses the absolute URL to replace relative path, so the image can render properly on PyPI.