### PR TITLE
Add exclusion rules for sdist and wheel build targets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,12 @@ pkglite = "pkglite.main:app"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.sdist]
+exclude = ["/docs", "/uv.lock", "/zensical.toml"]
+
+[tool.hatch.build.targets.wheel]
+exclude = ["/docs", "/uv.lock", "/zensical.toml"]
+
 [dependency-groups]
 dev = [
     "isort>=7.0.0",


### PR DESCRIPTION
To reduce the built file size.